### PR TITLE
build: use distroless:base-nossl-debian11 as base image of ingress-pipy

### DIFF
--- a/dockerfiles/ingress-pipy/Dockerfile
+++ b/dockerfiles/ingress-pipy/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM flomesh/pipy:0.70.0-46-nonroot as pipy
 
 # Build the final image
-FROM gcr.io/distroless/base-debian11:$DISTROLESS_TAG
+FROM gcr.io/distroless/base-nossl-debian11:$DISTROLESS_TAG
 WORKDIR /
 COPY --from=builder /workspace/bin/ingress-pipy .
 COPY --from=pipy /usr/local/bin/pipy /usr/local/bin/pipy


### PR DESCRIPTION
Signed-off-by: Lin Yang <reaver@flomesh.io>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Control Plane              | [ ] |
| Samples                    | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Performance                | [ ] |
| Security                   | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [ErieCanal docs](https://github.com/flomesh-io/ErieCanal/tree/main/docs) folder (if applicable)?